### PR TITLE
Changed the gemspec dependency of "active_support" to "activesupport".

### DIFF
--- a/pre.gemspec
+++ b/pre.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   ["rspec", "mocha", "pry-nav"].each {|lib| s.add_development_dependency lib}
   s.add_runtime_dependency "treetop"
-  s.add_runtime_dependency "active_support"
+  s.add_runtime_dependency "activesupport"
   s.add_runtime_dependency "dalli"
 end


### PR DESCRIPTION
Tried to install pre in a rails 4 project and got a failure bundling it

```
Could not find gem 'active_support (>= 0) ruby', which is required by gem 'pre (>= 0) ruby', in any of the sources.
```

Found another place that had this issue and documented the problem
https://github.com/chef/knife-vcloud/issues/5
It appears that a while back, there were some activesupport releases
done with the wrong name (active_support) which causes a failure when bundling in newer
releases.
