### PR TITLE
Treetop current version seems to have changed to .load instead of .re…

### DIFF
--- a/lib/pre/validator.rb
+++ b/lib/pre/validator.rb
@@ -74,7 +74,7 @@ module Pre
 
     def rfc2822_parser(treetop = Treetop)
       ['rfc2822_obsolete', 'rfc2822'].each do |grammar|
-        treetop.require File.join(File.dirname(__FILE__), grammar)
+        treetop.load File.join(File.dirname(__FILE__), grammar)
       end
       RFC2822Parser.new
     end


### PR DESCRIPTION
I was just doing an update to my codebase.  Looks like previously I'd been on treetop 1.6.2 and I updated to 1.6.3 and pre started failing saying that this call to treetop.require was private on line https://github.com/tastycode/pre/blob/master/lib/pre/validator.rb#L77

It looks like the Gemfile.lock in pre is currently looking at treetop 1.4.10 https://github.com/tastycode/pre/blob/master/Gemfile.lock#L38

Looking at treetop, I believe the method to use now is .load - changing it to this seems to work.
